### PR TITLE
Fix erroneous linguistics.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.com linguist-vendored


### PR DESCRIPTION
Ignore com extensions, as they were being registered as DCL, which is wrong.